### PR TITLE
Adjust login header spacing

### DIFF
--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/LoginScreen.kt
@@ -41,13 +41,21 @@ fun LoginScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White)
-            .padding(16.dp)
+            .padding(
+                start = 16.dp,
+                end = 16.dp,
+                top = 48.dp,
+                bottom = 16.dp
+            )
     ) {
-        Row(
+        Box(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
+            contentAlignment = Alignment.Center
         ) {
-            IconButton(onClick = onNavigateToSplash) {
+            IconButton(
+                onClick = onNavigateToSplash,
+                modifier = Modifier.align(Alignment.CenterStart)
+            ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "Volver"
@@ -57,7 +65,7 @@ fun LoginScreen(
                 text = "Ingresar",
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
             )
         }


### PR DESCRIPTION
## Summary
- increase the top padding of the login screen column so the header content sits lower on the page
- center the "Ingresar" header text while keeping the back arrow left-aligned

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ec3f6758688324b90bcdae80fdab9f