### PR TITLE
Restore home overview dashboard with quick actions

### DIFF
--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/HomeCompact.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/HomeCompact.kt
@@ -25,6 +25,7 @@ import com.example.appagendita_grupo1.ui.screens.home.components.HomeBottomBar
 import com.example.appagendita_grupo1.ui.screens.home.components.HomeTopHeader
 import com.example.appagendita_grupo1.ui.screens.home.sections.EventsSection
 import com.example.appagendita_grupo1.ui.screens.home.sections.MonthlyNotesSection
+import com.example.appagendita_grupo1.ui.screens.home.sections.OverviewSection
 import com.example.appagendita_grupo1.ui.screens.home.sections.TodayTasksSection
 import com.example.appagendita_grupo1.ui.theme.Bg
 import androidx.compose.ui.graphics.Color
@@ -44,7 +45,7 @@ fun HomeCompact(
 ) {
   val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
   var showSheet by remember { mutableStateOf(false) }
-  var selectedSection by remember { mutableStateOf(HomeSection.TodayTasks) }
+  var selectedSection by remember { mutableStateOf(HomeSection.Overview) }
 
   Scaffold(
     modifier = Modifier.padding(top = 16.dp),
@@ -72,6 +73,14 @@ fun HomeCompact(
       .padding(horizontal = 16.dp)
 
     when (selectedSection) {
+      HomeSection.Overview -> OverviewSection(
+        modifier = contentModifier,
+        onAddTask = onAddTask,
+        onAddNote = onAddNote,
+        onAddEvent = onAddEvent,
+        onOpenDetail = onOpenDetail
+      )
+
       HomeSection.TodayTasks -> TodayTasksSection(
         modifier = contentModifier,
         onAddTask = onAddTask

--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/HomeSection.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/HomeSection.kt
@@ -1,6 +1,7 @@
 package com.example.appagendita_grupo1.ui.screens.home
 
 enum class HomeSection(val label: String) {
+    Overview("Inicio"),
     TodayTasks("Tareas de hoy"),
     MonthlyNotes("Notas del mes"),
     Events("Eventos");

--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/sections/HomeSectionsContent.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/sections/HomeSectionsContent.kt
@@ -43,10 +43,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.example.appagendita_grupo1.ui.screens.home.components.ProgressTaskCard
+import com.example.appagendita_grupo1.ui.screens.home.components.ProjectHighlightCard
+import com.example.appagendita_grupo1.ui.screens.home.components.SectionHeader
+import com.example.appagendita_grupo1.ui.screens.home.components.TitleBlock
+import com.example.appagendita_grupo1.ui.screens.home.components.sampleTasks
 import com.example.appagendita_grupo1.ui.theme.AppTypography
 import com.example.appagendita_grupo1.ui.theme.BlueAccent
 import com.example.appagendita_grupo1.ui.theme.CardStroke
@@ -55,6 +61,93 @@ import com.example.appagendita_grupo1.ui.theme.PurplePrimary
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
+
+@Composable
+fun OverviewSection(
+    modifier: Modifier = Modifier,
+    onAddTask: () -> Unit,
+    onAddNote: () -> Unit,
+    onAddEvent: () -> Unit,
+    onOpenDetail: () -> Unit
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        contentPadding = PaddingValues(vertical = 8.dp, bottom = 96.dp)
+    ) {
+        item { TitleBlock() }
+        item {
+            QuickActionsRow(
+                onAddTask = onAddTask,
+                onAddNote = onAddNote,
+                onAddEvent = onAddEvent
+            )
+        }
+        item {
+            ProjectHighlightCard(onClick = onOpenDetail)
+        }
+        item {
+            SectionHeader(title = "En progreso")
+        }
+        items(sampleTasks) { task ->
+            ProgressTaskCard(task = task, onClick = onOpenDetail)
+        }
+    }
+}
+
+@Composable
+private fun QuickActionsRow(
+    onAddTask: () -> Unit,
+    onAddNote: () -> Unit,
+    onAddEvent: () -> Unit
+) {
+    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        item {
+            QuickActionChip(
+                label = "Crear nota",
+                icon = Icons.Outlined.Edit,
+                onClick = onAddNote
+            )
+        }
+        item {
+            QuickActionChip(
+                label = "Crear tarea",
+                icon = Icons.Outlined.AddCircle,
+                onClick = onAddTask
+            )
+        }
+        item {
+            QuickActionChip(
+                label = "Crear evento",
+                icon = Icons.Outlined.Schedule,
+                onClick = onAddEvent
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickActionChip(
+    label: String,
+    icon: ImageVector,
+    onClick: () -> Unit
+) {
+    AssistChip(
+        onClick = onClick,
+        label = {
+            Text(text = label, style = AppTypography.bodyMedium)
+        },
+        leadingIcon = {
+            Icon(imageVector = icon, contentDescription = null)
+        },
+        colors = AssistChipDefaults.assistChipColors(
+            containerColor = Color.White,
+            labelColor = NavyText,
+            leadingIconContentColor = PurplePrimary
+        ),
+        border = BorderStroke(1.dp, CardStroke)
+    )
+}
 
 @Composable
 fun TodayTasksSection(


### PR DESCRIPTION
## Summary
- introduce an overview section that recreates the "Hagamos hábitos juntos" dashboard with quick actions, featured project, and progress list
- register the overview tab in the home sections enum and make it the default selection in the compact layout
- wire the compact home scaffold to render the overview content alongside the existing tasks, notes, and events sections

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f57a1e9e408324b4352f53a3e0841b