### PR TITLE
Add task status tabs to compact home overview

### DIFF
--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/components/TaskCard.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/components/TaskCard.kt
@@ -14,8 +14,13 @@ import androidx.compose.material.icons.outlined.ChevronRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.appagendita_grupo1.ui.theme.CardStroke
 import com.example.appagendita_grupo1.ui.theme.NavyText
+import com.example.appagendita_grupo1.ui.theme.PurplePrimary
 
 @Composable
 fun SectionHeader(title: String) {
@@ -36,11 +42,56 @@ fun SectionHeader(title: String) {
   }
 }
 
-data class TaskUi(val title: String, val subtitle: String, val progress: Int)
+enum class TaskStatus(val label: String) {
+  Todo("Por hacer"),
+  InProgress("En progreso"),
+  Done("Completadas")
+}
+
+data class TaskUi(
+  val title: String,
+  val subtitle: String,
+  val progress: Int,
+  val status: TaskStatus
+)
+
 val sampleTasks = listOf(
-  TaskUi("Create Detail Booking", "Productivity Mobile App · Hace 2 min", 60),
-  TaskUi("Revision Home Page", "Banking Mobile App · Hace 5 min", 70),
-  TaskUi("Working On Landing Page", "Online Course · Hace 7 min", 80)
+  TaskUi(
+    title = "Crear prototipo de reservas",
+    subtitle = "App de productividad · Hace 2 min",
+    progress = 60,
+    status = TaskStatus.InProgress
+  ),
+  TaskUi(
+    title = "Diseñar pantalla de inicio",
+    subtitle = "Banca móvil · Hace 5 min",
+    progress = 70,
+    status = TaskStatus.InProgress
+  ),
+  TaskUi(
+    title = "Preparar briefing con el cliente",
+    subtitle = "Marketing digital · Hace 10 min",
+    progress = 0,
+    status = TaskStatus.Todo
+  ),
+  TaskUi(
+    title = "Redactar documentación técnica",
+    subtitle = "Sistema interno · Hace 15 min",
+    progress = 10,
+    status = TaskStatus.Todo
+  ),
+  TaskUi(
+    title = "Publicar landing page",
+    subtitle = "Curso online · Hace 20 min",
+    progress = 100,
+    status = TaskStatus.Done
+  ),
+  TaskUi(
+    title = "Enviar informe semanal",
+    subtitle = "Equipo de ventas · Hace 25 min",
+    progress = 100,
+    status = TaskStatus.Done
+  )
 )
 
 @Composable
@@ -68,6 +119,49 @@ fun ProgressTaskCard(task: TaskUi, onClick: () -> Unit) {
   }
 }
 
+@Composable
+fun TaskStatusTabs(
+  selectedStatus: TaskStatus,
+  onStatusSelected: (TaskStatus) -> Unit,
+  modifier: Modifier = Modifier
+) {
+  val statuses = remember { TaskStatus.values().toList() }
+  val selectedIndex = statuses.indexOf(selectedStatus).coerceAtLeast(0)
+
+  TabRow(
+    selectedTabIndex = selectedIndex,
+    modifier = modifier.fillMaxWidth(),
+    containerColor = Color.Transparent,
+    contentColor = NavyText,
+    indicator = { tabPositions ->
+      if (tabPositions.isNotEmpty()) {
+        TabRowDefaults.SecondaryIndicator(
+          modifier = Modifier
+            .tabIndicatorOffset(tabPositions[selectedIndex])
+            .height(3.dp),
+          color = PurplePrimary
+        )
+      }
+    },
+    divider = {}
+  ) {
+    statuses.forEach { status ->
+      val selected = status == selectedStatus
+      Tab(
+        selected = selected,
+        onClick = { onStatusSelected(status) }
+      ) {
+        Text(
+          text = status.label,
+          style = MaterialTheme.typography.bodyMedium,
+          color = if (selected) NavyText else NavyText.copy(alpha = .6f),
+          modifier = Modifier.padding(vertical = 12.dp)
+        )
+      }
+    }
+  }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun SectionHeaderPreview() {
@@ -77,5 +171,11 @@ fun SectionHeaderPreview() {
 @Preview(showBackground = true)
 @Composable
 fun ProgressTaskCardPreview() {
-    ProgressTaskCard(task = sampleTasks.first(), onClick = {})
+    ProgressTaskCard(task = sampleTasks.first { it.status == TaskStatus.InProgress }, onClick = {})
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TaskStatusTabsPreview() {
+    TaskStatusTabs(selectedStatus = TaskStatus.InProgress, onStatusSelected = {})
 }

--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/sections/HomeSectionsContent.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/home/sections/HomeSectionsContent.kt
@@ -52,6 +52,8 @@ import com.example.appagendita_grupo1.ui.screens.home.components.ProgressTaskCar
 import com.example.appagendita_grupo1.ui.screens.home.components.ProjectHighlightCard
 import com.example.appagendita_grupo1.ui.screens.home.components.SectionHeader
 import com.example.appagendita_grupo1.ui.screens.home.components.TitleBlock
+import com.example.appagendita_grupo1.ui.screens.home.components.TaskStatus
+import com.example.appagendita_grupo1.ui.screens.home.components.TaskStatusTabs
 import com.example.appagendita_grupo1.ui.screens.home.components.sampleTasks
 import com.example.appagendita_grupo1.ui.theme.AppTypography
 import com.example.appagendita_grupo1.ui.theme.BlueAccent
@@ -70,6 +72,19 @@ fun OverviewSection(
     onAddEvent: () -> Unit,
     onOpenDetail: () -> Unit
 ) {
+    var selectedTaskStatus by remember { mutableStateOf(TaskStatus.InProgress) }
+    val filteredTasks = remember(selectedTaskStatus) {
+        sampleTasks.filter { it.status == selectedTaskStatus }
+    }
+
+    val emptyTaskMessage = remember(selectedTaskStatus) {
+        when (selectedTaskStatus) {
+            TaskStatus.Todo -> "No tienes tareas pendientes por realizar."
+            TaskStatus.InProgress -> "No hay tareas en progreso en este momento."
+            TaskStatus.Done -> "Aún no se han completado tareas."
+        }
+    }
+
     LazyColumn(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -86,11 +101,24 @@ fun OverviewSection(
         item {
             ProjectHighlightCard(onClick = onOpenDetail)
         }
+        item { SectionHeader(title = "Tareas") }
         item {
-            SectionHeader(title = "En progreso")
+            TaskStatusTabs(
+                selectedStatus = selectedTaskStatus,
+                onStatusSelected = { selectedTaskStatus = it }
+            )
         }
-        items(sampleTasks) { task ->
-            ProgressTaskCard(task = task, onClick = onOpenDetail)
+        if (filteredTasks.isNotEmpty()) {
+            items(filteredTasks) { task ->
+                ProgressTaskCard(task = task, onClick = onOpenDetail)
+            }
+        } else {
+            item {
+                EmptyStateCard(
+                    title = "Sin tareas",
+                    message = emptyTaskMessage
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add task status filter tabs to the compact home overview
- extend task cards with status metadata and provide sample data for each tab
- show an empty-state card when a selected tab has no tasks

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e66f89bc832482cbe6ea754f3008