### PR TITLE
Enhance Add Task screen with interactive inputs

### DIFF
--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/AddTaskScreen.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/AddTaskScreen.kt
@@ -1,24 +1,120 @@
 package com.example.appagendita_grupo1.ui.screens
 
-import androidx.compose.foundation.layout.*
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.outlined.AccessTime
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimePickerState
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.appagendita_grupo1.ui.theme.AppAgendita_Grupo1Theme
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddTaskScreen(
     onBack: () -> Unit,
+    viewModel: AddTaskViewModel = viewModel()
 ) {
+    val uiState = viewModel.uiState
+    val context = LocalContext.current
+    val locale = remember { context.resources.configuration.locales[0] ?: Locale.getDefault() }
+
+    var showDatePicker by remember { mutableStateOf(false) }
+    var showStartTimePicker by remember { mutableStateOf(false) }
+    var showEndTimePicker by remember { mutableStateOf(false) }
+
+    val datePickerState = rememberDatePickerState(initialSelectedDateMillis = uiState.startDate.toEpochMillis())
+    val startTimePickerState = rememberTimePickerState(
+        initialHour = uiState.startTime.hour,
+        initialMinute = uiState.startTime.minute,
+        is24Hour = false
+    )
+    val endTimePickerState = rememberTimePickerState(
+        initialHour = uiState.endTime.hour,
+        initialMinute = uiState.endTime.minute,
+        is24Hour = false
+    )
+
+    LaunchedEffect(uiState.startDate) {
+        datePickerState.selectedDateMillis = uiState.startDate.toEpochMillis()
+    }
+
+    LaunchedEffect(uiState.startTime) {
+        startTimePickerState.setTime(uiState.startTime)
+    }
+
+    LaunchedEffect(uiState.endTime) {
+        endTimePickerState.setTime(uiState.endTime)
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -33,106 +129,436 @@ fun AddTaskScreen(
     ) { innerPadding ->
         Column(
             modifier = Modifier
+                .fillMaxSize()
                 .padding(innerPadding)
-                .padding(16.dp)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text("Nombre Tarea")
-            OutlinedTextField(
-                value = "Mobile Application design",
-                onValueChange = {},
-                modifier = Modifier.fillMaxWidth(),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
+            CardSection(title = "Detalles de la tarea") {
+                OutlinedTextField(
+                    value = uiState.taskName,
+                    onValueChange = viewModel::onTaskNameChange,
+                    label = { Text("Nombre de la tarea") },
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = uiState.taskNameError != null,
+                    supportingText = {
+                        uiState.taskNameError?.let { Text(it) }
+                    }
+                )
 
-            Text("Miembros Tarea")
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                items(4) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.AccountCircle,
-                            contentDescription = "Member",
-                            modifier = Modifier.size(40.dp)
+                OutlinedTextField(
+                    value = uiState.description,
+                    onValueChange = viewModel::onDescriptionChange,
+                    label = { Text("Descripción (opcional)") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(120.dp),
+                    maxLines = 5
+                )
+
+                Text(
+                    text = "Miembros",
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                )
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    items(3) {
+                        MemberChip(name = "Jeny")
+                    }
+                    item {
+                        AssistChip(
+                            onClick = { /* TODO seleccionar miembros */ },
+                            label = { Text("Agregar") },
+                            leadingIcon = {
+                                Icon(Icons.Filled.Add, contentDescription = null)
+                            }
                         )
-                        Text(text = "Jeny")
                     }
                 }
-                item {
-                    IconButton(onClick = { /*TODO*/ }) {
-                        Icon(
-                            imageVector = Icons.Filled.Add,
-                            contentDescription = "Add Member"
+            }
+
+            CardSection(title = "Horario") {
+                PickerTextField(
+                    label = "Fecha de inicio",
+                    value = uiState.startDate.formatDisplay(locale),
+                    onClick = { showDatePicker = true },
+                    leadingIcon = Icons.Outlined.CalendarMonth
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    PickerTextField(
+                        label = "Hora de inicio",
+                        value = uiState.startTime.formatDisplay(locale),
+                        onClick = { showStartTimePicker = true },
+                        leadingIcon = Icons.Outlined.AccessTime,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    PickerTextField(
+                        label = "Hora de término",
+                        value = uiState.endTime.formatDisplay(locale),
+                        onClick = { showEndTimePicker = true },
+                        leadingIcon = Icons.Outlined.AccessTime,
+                        modifier = Modifier.weight(1f),
+                        isError = uiState.timeError != null,
+                        supportingText = uiState.timeError
+                    )
+                }
+
+                ReminderDropdown(
+                    selectedOption = uiState.reminder,
+                    onOptionSelected = viewModel::onReminderSelected
+                )
+            }
+
+            CardSection(title = "Categorización") {
+                Text(
+                    text = "Tipo",
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    TaskType.values().forEach { type ->
+                        FilterChip(
+                            selected = uiState.taskType == type,
+                            onClick = { viewModel.onTaskTypeSelected(type) },
+                            label = { Text(type.displayName) }
+                        )
+                    }
+                }
+
+                Text(
+                    text = "Color",
+                    style = MaterialTheme.typography.labelLarge,
+                    modifier = Modifier.padding(top = 16.dp, bottom = 8.dp)
+                )
+                LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    items(TaskColorOption.pastelPalette.size) { index ->
+                        val option = TaskColorOption.pastelPalette[index]
+                        ColorOptionChip(
+                            option = option,
+                            isSelected = uiState.selectedColor == option,
+                            onClick = { viewModel.onColorSelected(option) }
                         )
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(16.dp))
 
-            Text("Fecha Inicio")
-            OutlinedTextField(
-                value = "Noviembre 01, 2025",
-                onValueChange = {},
-                modifier = Modifier.fillMaxWidth()
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Hora de Inicio")
-                    OutlinedTextField(
-                        value = "9:30 am",
-                        onValueChange = {},
-                        modifier = Modifier.fillMaxWidth()
+            CardSection(title = "Subtareas") {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Añadir subtareas", style = MaterialTheme.typography.bodyLarge)
+                    Switch(
+                        checked = uiState.subtasksEnabled,
+                        onCheckedChange = viewModel::onSubtasksToggle
                     )
                 }
-                Column(modifier = Modifier.weight(1f)) {
-                    Text("Hora de Termino")
-                    OutlinedTextField(
-                        value = "3:30 pm",
-                        onValueChange = {},
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(16.dp))
-            Text("Tipo")
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                var selected by remember { mutableStateOf("En proceso") }
-                val types = listOf("Urgente", "En proceso", "pendiente")
 
-                types.forEach { type ->
-                    FilterChip(
-                        selected = selected == type,
-                        onClick = { selected = type },
-                        label = { Text(type) }
-                    )
+                if (uiState.subtasksEnabled) {
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        uiState.subtasks.forEach { subtask ->
+                            SubtaskRow(
+                                subtask = subtask,
+                                onTitleChange = { viewModel.onSubtaskTitleChange(subtask.id, it) },
+                                onCheckedChange = { viewModel.onSubtaskCheckedChange(subtask.id, it) },
+                                onRemove = { viewModel.onRemoveSubtask(subtask.id) }
+                            )
+                        }
+
+                        TextButton(onClick = viewModel::onAddSubtask) {
+                            Icon(Icons.Filled.Add, contentDescription = null)
+                            Spacer(Modifier.size(4.dp))
+                            Text("Agregar subtarea")
+                        }
+                    }
                 }
             }
 
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.weight(1f, fill = true))
+
             Button(
-                onClick = { /*TODO*/ },
-                modifier = Modifier.fillMaxWidth()
+                onClick = { /* TODO Guardar tarea */ },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = uiState.canSave
             ) {
                 Text("Guardar")
             }
         }
     }
+
+    if (showDatePicker) {
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        datePickerState.selectedDateMillis?.let {
+                            viewModel.onDateSelected(it.toLocalDate())
+                        }
+                        showDatePicker = false
+                    }
+                ) {
+                    Text("Seleccionar")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDatePicker = false }) { Text("Cancelar") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    if (showStartTimePicker) {
+        TimePickerDialog(
+            onDismissRequest = { showStartTimePicker = false },
+            onConfirm = {
+                viewModel.onStartTimeSelected(startTimePickerState.toLocalTime())
+                showStartTimePicker = false
+            },
+            state = startTimePickerState,
+            title = "Seleccionar hora de inicio"
+        )
+    }
+
+    if (showEndTimePicker) {
+        TimePickerDialog(
+            onDismissRequest = { showEndTimePicker = false },
+            onConfirm = {
+                viewModel.onEndTimeSelected(endTimePickerState.toLocalTime())
+                showEndTimePicker = false
+            },
+            state = endTimePickerState,
+            title = "Seleccionar hora de término"
+        )
+    }
 }
 
-@Preview(showBackground = true)
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TimePickerDialog(
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+    state: TimePickerState,
+    title: String
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text("Aceptar") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) { Text("Cancelar") }
+        },
+        title = { Text(title) },
+        text = { TimePicker(state = state) }
+    )
+}
+
+@Composable
+private fun CardSection(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            HorizontalDivider()
+            content()
+        }
+    }
+}
+
+@Composable
+private fun MemberChip(name: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.AccountCircle,
+                contentDescription = null,
+                modifier = Modifier.size(36.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodySmall,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun PickerTextField(
+    label: String,
+    value: String,
+    onClick: () -> Unit,
+    leadingIcon: ImageVector,
+    modifier: Modifier = Modifier,
+    isError: Boolean = false,
+    supportingText: String? = null
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    OutlinedTextField(
+        value = value,
+        onValueChange = {},
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            ),
+        label = { Text(label) },
+        leadingIcon = { Icon(leadingIcon, contentDescription = null) },
+        readOnly = true,
+        isError = isError,
+        supportingText = supportingText?.let { { Text(it) } }
+    )
+}
+
+@Composable
+private fun ColorOptionChip(
+    option: TaskColorOption,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    AssistChip(
+        onClick = onClick,
+        label = { Text(option.label) },
+        leadingIcon = {
+            Box(
+                modifier = Modifier
+                    .size(20.dp)
+                    .background(color = option.color, shape = CircleShape)
+            )
+        },
+        colors = AssistChipDefaults.assistChipColors(
+            containerColor = if (isSelected) option.color.copy(alpha = 0.24f) else MaterialTheme.colorScheme.surface,
+            labelColor = MaterialTheme.colorScheme.onSurface
+        ),
+        border = AssistChipDefaults.assistChipBorder(
+            borderColor = if (isSelected) option.color else MaterialTheme.colorScheme.outline
+        )
+    )
+}
+
+@Composable
+private fun SubtaskRow(
+    subtask: SubtaskUiState,
+    onTitleChange: (String) -> Unit,
+    onCheckedChange: (Boolean) -> Unit,
+    onRemove: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Checkbox(checked = subtask.isDone, onCheckedChange = onCheckedChange)
+        OutlinedTextField(
+            value = subtask.title,
+            onValueChange = onTitleChange,
+            label = { Text("Subtarea") },
+            modifier = Modifier.weight(1f)
+        )
+        IconButton(onClick = onRemove) {
+            Icon(Icons.Outlined.Close, contentDescription = "Eliminar subtarea")
+        }
+    }
+}
+
+@Composable
+private fun ReminderDropdown(
+    selectedOption: ReminderOption,
+    onOptionSelected: (ReminderOption) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = selectedOption.label,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Recordatorio") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            colors = TextFieldDefaults.outlinedTextFieldColors(),
+            modifier = Modifier
+                .menuAnchor()
+                .fillMaxWidth()
+        )
+        androidx.compose.material3.ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            ReminderOption.values().forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(option.label) },
+                    onClick = {
+                        onOptionSelected(option)
+                        expanded = false
+                    },
+                    leadingIcon = { Icon(Icons.Outlined.Edit, contentDescription = null) }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Composable
 fun AddTaskScreenPreview() {
     AppAgendita_Grupo1Theme {
-        AddTaskScreen {}
+        AddTaskScreen(onBack = {})
     }
+}
+
+private fun TimePickerState.setTime(time: LocalTime) {
+    this.hour = time.hour
+    this.minute = time.minute
+}
+
+private fun TimePickerState.toLocalTime(): LocalTime = LocalTime.of(hour, minute)
+
+private fun LocalTime.formatDisplay(locale: Locale): String {
+    val formatter = DateTimeFormatter.ofPattern("h:mm a", locale)
+    return format(formatter).lowercase(locale)
+}
+
+private fun LocalDate.formatDisplay(locale: Locale): String {
+    val formatter = DateTimeFormatter.ofPattern("d 'de' MMMM yyyy", locale)
+    return format(formatter)
+}
+
+private fun LocalDate.toEpochMillis(): Long {
+    return atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+}
+
+private fun Long.toLocalDate(): LocalDate {
+    return Instant.ofEpochMilli(this).atZone(ZoneId.systemDefault()).toLocalDate()
 }

--- a/app/src/main/java/com/example/appagendita_grupo1/ui/screens/AddTaskViewModel.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/ui/screens/AddTaskViewModel.kt
@@ -1,0 +1,158 @@
+package com.example.appagendita_grupo1.ui.screens
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.ViewModel
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class AddTaskViewModel : ViewModel() {
+    var uiState by mutableStateOf(AddTaskUiState())
+        private set
+
+    private var nextSubtaskId = 0L
+
+    init {
+        val now = LocalDateTime.now()
+        val normalizedStart = now.toLocalTime().withSecond(0).withNano(0)
+        val defaultEnd = normalizedStart.plusHours(1)
+        uiState = uiState.copy(
+            startDate = now.toLocalDate(),
+            startTime = normalizedStart,
+            endTime = defaultEnd,
+            selectedColor = TaskColorOption.pastelPalette.first()
+        )
+    }
+
+    fun onTaskNameChange(value: String) {
+        val error = if (value.isBlank()) "El nombre de la tarea no puede estar vacío" else null
+        uiState = uiState.copy(taskName = value, taskNameError = error)
+    }
+
+    fun onDescriptionChange(value: String) {
+        uiState = uiState.copy(description = value)
+    }
+
+    fun onDateSelected(date: LocalDate) {
+        uiState = uiState.copy(startDate = date)
+    }
+
+    fun onStartTimeSelected(time: LocalTime) {
+        var newEndTime = uiState.endTime
+        if (!time.isBefore(newEndTime)) {
+            newEndTime = time.plusMinutes(30)
+        }
+        uiState = uiState.copy(startTime = time, endTime = newEndTime, timeError = null)
+    }
+
+    fun onEndTimeSelected(time: LocalTime) {
+        if (time.isBefore(uiState.startTime)) {
+            uiState = uiState.copy(timeError = "La hora de término no puede ser anterior a la de inicio")
+        } else {
+            uiState = uiState.copy(endTime = time, timeError = null)
+        }
+    }
+
+    fun onTaskTypeSelected(type: TaskType) {
+        uiState = uiState.copy(taskType = type)
+    }
+
+    fun onColorSelected(option: TaskColorOption) {
+        uiState = uiState.copy(selectedColor = option)
+    }
+
+    fun onReminderSelected(option: ReminderOption) {
+        uiState = uiState.copy(reminder = option)
+    }
+
+    fun onSubtasksToggle(enabled: Boolean) {
+        if (enabled) {
+            val updatedSubtasks = if (uiState.subtasks.isEmpty()) listOf(createSubtask()) else uiState.subtasks
+            uiState = uiState.copy(subtasksEnabled = true, subtasks = updatedSubtasks)
+        } else {
+            uiState = uiState.copy(subtasksEnabled = false, subtasks = emptyList())
+        }
+    }
+
+    fun onAddSubtask() {
+        if (!uiState.subtasksEnabled) return
+        uiState = uiState.copy(subtasks = uiState.subtasks + createSubtask())
+    }
+
+    fun onSubtaskTitleChange(id: Long, title: String) {
+        uiState = uiState.copy(
+            subtasks = uiState.subtasks.map { subtask ->
+                if (subtask.id == id) subtask.copy(title = title) else subtask
+            }
+        )
+    }
+
+    fun onSubtaskCheckedChange(id: Long, checked: Boolean) {
+        uiState = uiState.copy(
+            subtasks = uiState.subtasks.map { subtask ->
+                if (subtask.id == id) subtask.copy(isDone = checked) else subtask
+            }
+        )
+    }
+
+    fun onRemoveSubtask(id: Long) {
+        uiState = uiState.copy(subtasks = uiState.subtasks.filterNot { it.id == id })
+    }
+
+    private fun createSubtask(): SubtaskUiState {
+        return SubtaskUiState(id = nextSubtaskId++)
+    }
+}
+
+data class AddTaskUiState(
+    val taskName: String = "",
+    val description: String = "",
+    val startDate: LocalDate = LocalDate.now(),
+    val startTime: LocalTime = LocalTime.now().withSecond(0).withNano(0),
+    val endTime: LocalTime = LocalTime.now().withSecond(0).withNano(0).plusHours(1),
+    val taskType: TaskType = TaskType.IN_PROGRESS,
+    val selectedColor: TaskColorOption = TaskColorOption.pastelPalette.first(),
+    val subtasksEnabled: Boolean = false,
+    val subtasks: List<SubtaskUiState> = emptyList(),
+    val reminder: ReminderOption = ReminderOption.NONE,
+    val taskNameError: String? = null,
+    val timeError: String? = null
+) {
+    val canSave: Boolean get() = taskName.isNotBlank() && timeError == null
+}
+
+data class SubtaskUiState(
+    val id: Long,
+    val title: String = "",
+    val isDone: Boolean = false
+)
+
+enum class TaskType(val displayName: String) {
+    URGENT("Urgente"),
+    IN_PROGRESS("En proceso"),
+    PENDING("Pendiente");
+}
+
+enum class ReminderOption(val label: String) {
+    NONE("Sin recordatorio"),
+    FIFTEEN_MINUTES("15 minutos antes"),
+    ONE_HOUR("1 hora antes"),
+    ONE_DAY("El día anterior"),
+    CUSTOM("Personalizado");
+}
+
+data class TaskColorOption(val label: String, val color: Color) {
+    companion object {
+        val pastelPalette: List<TaskColorOption> = listOf(
+            TaskColorOption("Lavanda", Color(0xFFD7C2F9)),
+            TaskColorOption("Melocotón", Color(0xFFFFD8C2)),
+            TaskColorOption("Aqua", Color(0xFFC2F2F0)),
+            TaskColorOption("Menta", Color(0xFFC9F7D5)),
+            TaskColorOption("Sol", Color(0xFFFFF0B3)),
+            TaskColorOption("Cielo", Color(0xFFC7E5FF))
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- replace the static form on AddTaskScreen with interactive date/time pickers, reminder options, and reorganized sections
- introduce an AddTaskViewModel to manage state, validation, subtasks, and a pastel color palette for categorizing tasks
- add support for optional descriptions and configurable subtasks to make task creation more flexible

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7f1221b788324985fdb39f2515795