### PR TITLE
Implement Room persistence layer for users

### DIFF
--- a/app/src/main/java/com/example/appagendita_grupo1/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/data/local/database/AppDatabase.kt
@@ -1,0 +1,57 @@
+package com.example.appagendita_grupo1.data.local.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import java.util.concurrent.Executors
+import kotlinx.coroutines.runBlocking
+
+@Database(
+    entities = [UserEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class AppDatabase : RoomDatabase() {
+
+    abstract fun userDao(): UserDao
+
+    companion object {
+        private const val DATABASE_NAME = "appagendita_users.db"
+
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        private val databaseExecutor = Executors.newSingleThreadExecutor()
+
+        fun getInstance(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: buildDatabase(context.applicationContext).also { INSTANCE = it }
+            }
+        }
+
+        private fun buildDatabase(appContext: Context): AppDatabase {
+            return Room.databaseBuilder(appContext, AppDatabase::class.java, DATABASE_NAME)
+                .addCallback(object : RoomDatabase.Callback() {
+                    override fun onCreate(db: SupportSQLiteDatabase) {
+                        super.onCreate(db)
+                        databaseExecutor.execute {
+                            INSTANCE?.let { database ->
+                                val seedUser = UserEntity(
+                                    username = "Invitado",
+                                    email = "invitado@appagendita.com",
+                                    passwordHash = "guest"
+                                )
+                                runBlocking {
+                                    database.userDao().insert(seedUser)
+                                }
+                            }
+                        }
+                    }
+                })
+                .fallbackToDestructiveMigration()
+                .build()
+        }
+    }
+}

--- a/app/src/main/java/com/example/appagendita_grupo1/data/local/database/UserDao.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/data/local/database/UserDao.kt
@@ -1,0 +1,50 @@
+package com.example.appagendita_grupo1.data.local.database
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface UserDao {
+    @Query("SELECT * FROM users ORDER BY created_at DESC")
+    fun observeUsers(): Flow<List<UserEntity>>
+
+    @Query("SELECT * FROM users WHERE email = :email LIMIT 1")
+    suspend fun findByEmail(email: String): UserEntity?
+
+    @Query("SELECT * FROM users WHERE id = :id")
+    suspend fun findById(id: Long): UserEntity?
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(user: UserEntity): Long
+
+    @Update
+    suspend fun update(user: UserEntity)
+
+    @Delete
+    suspend fun delete(user: UserEntity)
+
+    @Query("DELETE FROM users")
+    suspend fun clear()
+
+    @Transaction
+    suspend fun upsert(user: UserEntity): Long {
+        val existing = findByEmail(user.normalizedEmail())
+        return if (existing == null) {
+            insert(user.copy(email = user.normalizedEmail()))
+        } else {
+            val updated = user.copy(
+                id = existing.id,
+                createdAt = existing.createdAt,
+                email = user.normalizedEmail()
+            )
+            update(updated)
+            existing.id
+        }
+    }
+}

--- a/app/src/main/java/com/example/appagendita_grupo1/data/local/database/UserEntity.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/data/local/database/UserEntity.kt
@@ -1,0 +1,26 @@
+package com.example.appagendita_grupo1.data.local.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "users")
+data class UserEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    val id: Long = 0L,
+    @ColumnInfo(name = "username")
+    val username: String,
+    @ColumnInfo(name = "email")
+    val email: String,
+    @ColumnInfo(name = "password_hash")
+    val passwordHash: String,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long = System.currentTimeMillis()
+) {
+    fun hasValidCredentials(): Boolean = username.isNotBlank() && email.isNotBlank() && passwordHash.isNotBlank()
+
+    fun matchesPassword(rawHash: String): Boolean = passwordHash == rawHash
+
+    fun normalizedEmail(): String = email.trim().lowercase()
+}

--- a/app/src/main/java/com/example/appagendita_grupo1/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/repository/UserRepository.kt
@@ -1,0 +1,78 @@
+package com.example.appagendita_grupo1.repository
+
+import com.example.appagendita_grupo1.data.local.database.UserDao
+import com.example.appagendita_grupo1.data.local.database.UserEntity
+import com.example.appagendita_grupo1.storage.UserPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+class UserRepository(
+    private val userDao: UserDao,
+    private val preferences: UserPreferences
+) {
+
+    fun observeUsers(): Flow<List<UserEntity>> = userDao.observeUsers()
+
+    fun observeLastSession(): StateFlow<UserPreferences.LastUser?> = preferences.observeLastUser()
+
+    suspend fun registerUser(username: String, email: String, passwordHash: String): Result<UserEntity> {
+        val trimmedName = username.trim()
+        val normalizedEmail = email.trim().lowercase()
+        if (trimmedName.isEmpty() || normalizedEmail.isEmpty() || passwordHash.isBlank()) {
+            return Result.failure(IllegalArgumentException("Los datos del usuario son inválidos"))
+        }
+
+        val entity = UserEntity(
+            username = trimmedName,
+            email = normalizedEmail,
+            passwordHash = passwordHash
+        )
+
+        if (!entity.hasValidCredentials()) {
+            return Result.failure(IllegalArgumentException("Los datos del usuario son inválidos"))
+        }
+
+        val existing = userDao.findByEmail(normalizedEmail)
+        if (existing != null) {
+            return Result.failure(IllegalStateException("El correo ya está registrado"))
+        }
+
+        val id = userDao.insert(entity)
+        val stored = userDao.findById(id)
+            ?: return Result.failure(IllegalStateException("No se pudo recuperar el usuario creado"))
+
+        preferences.saveLastUser(stored)
+        return Result.success(stored)
+    }
+
+    suspend fun authenticate(email: String, passwordHash: String): Result<UserEntity> {
+        val normalizedEmail = email.trim().lowercase()
+        val user = userDao.findByEmail(normalizedEmail)
+            ?: return Result.failure(IllegalArgumentException("Usuario no encontrado"))
+
+        return if (user.matchesPassword(passwordHash)) {
+            preferences.saveLastUser(user)
+            Result.success(user)
+        } else {
+            Result.failure(IllegalArgumentException("Contraseña incorrecta"))
+        }
+    }
+
+    suspend fun updateUser(entity: UserEntity): Result<UserEntity> {
+        if (!entity.hasValidCredentials()) {
+            return Result.failure(IllegalArgumentException("Los datos del usuario son inválidos"))
+        }
+        userDao.update(entity.copy(email = entity.normalizedEmail()))
+        val refreshed = userDao.findById(entity.id)
+            ?: return Result.failure(IllegalStateException("No se pudo actualizar el usuario"))
+        return Result.success(refreshed)
+    }
+
+    suspend fun deleteUser(entity: UserEntity) {
+        userDao.delete(entity)
+        val last = preferences.currentUser()
+        if (last?.userId == entity.id) {
+            preferences.clearLastUser()
+        }
+    }
+}

--- a/app/src/main/java/com/example/appagendita_grupo1/storage/UserPreferences.kt
+++ b/app/src/main/java/com/example/appagendita_grupo1/storage/UserPreferences.kt
@@ -1,0 +1,61 @@
+package com.example.appagendita_grupo1.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.example.appagendita_grupo1.data.local.database.UserEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class UserPreferences(context: Context) {
+
+    private val sharedPreferences: SharedPreferences =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val lastUserState = MutableStateFlow(readLastUser())
+
+    fun observeLastUser(): StateFlow<LastUser?> = lastUserState.asStateFlow()
+
+    fun currentUser(): LastUser? = lastUserState.value
+
+    fun saveLastUser(user: UserEntity) {
+        val lastUser = LastUser(user.id, user.username, user.email)
+        sharedPreferences.edit()
+            .putLong(KEY_USER_ID, user.id)
+            .putString(KEY_USER_NAME, user.username)
+            .putString(KEY_USER_EMAIL, user.email)
+            .apply()
+        lastUserState.value = lastUser
+    }
+
+    fun clearLastUser() {
+        sharedPreferences.edit()
+            .remove(KEY_USER_ID)
+            .remove(KEY_USER_NAME)
+            .remove(KEY_USER_EMAIL)
+            .apply()
+        lastUserState.value = null
+    }
+
+    private fun readLastUser(): LastUser? {
+        val id = sharedPreferences.getLong(KEY_USER_ID, DEFAULT_ID)
+        if (id == DEFAULT_ID) return null
+        val name = sharedPreferences.getString(KEY_USER_NAME, null) ?: return null
+        val email = sharedPreferences.getString(KEY_USER_EMAIL, null) ?: return null
+        return LastUser(id, name, email)
+    }
+
+    data class LastUser(
+        val userId: Long,
+        val username: String,
+        val email: String
+    )
+
+    companion object {
+        private const val PREFS_NAME = "appagendita_user_prefs"
+        private const val KEY_USER_ID = "key_user_id"
+        private const val KEY_USER_NAME = "key_user_name"
+        private const val KEY_USER_EMAIL = "key_user_email"
+        private const val DEFAULT_ID = -1L
+    }
+}


### PR DESCRIPTION
## Summary
- add a Room database with user entity, DAO, and seeded initialization for AppAgendita
- create a user repository that validates inputs, performs persistence, and exposes session flow
- provide shared-preferences backed user preferences helper for last session tracking

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fffce958348324b446d46466dea1c6